### PR TITLE
updated requirement of hug to >=2.4.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Hug==2.3.2
+Hug>=2.4.1
 Pillow==4.3.0
 python-slugify==1.2.4
 ujson==1.35


### PR DESCRIPTION
Hug version needs to be >= 2.4.1 to support python 3.7, see also https://github.com/hugapi/hug/issues/631